### PR TITLE
Feat/adding currency selection

### DIFF
--- a/src/app/Context/CryptoContext.jsx
+++ b/src/app/Context/CryptoContext.jsx
@@ -12,6 +12,7 @@ export const CryptoProvider = ({ children }) => {
   const [marketData, setMarketData] = useState([]);
   const [bitCoinData, setBitCoinData] = useState([]);
   const [userAssetData, setUserAssetData] = useState([]);
+  const [currency, setCurrency] = useState("en");
 
   return (
     <CryptoContext.Provider
@@ -22,6 +23,8 @@ export const CryptoProvider = ({ children }) => {
         setBitCoinData,
         userAssetData,
         setUserAssetData,
+        currency,
+        setCurrency
       }}
     >
       {children}

--- a/src/app/Context/CryptoContext.jsx
+++ b/src/app/Context/CryptoContext.jsx
@@ -12,7 +12,7 @@ export const CryptoProvider = ({ children }) => {
   const [marketData, setMarketData] = useState([]);
   const [bitCoinData, setBitCoinData] = useState([]);
   const [userAssetData, setUserAssetData] = useState([]);
-  const [currency, setCurrency] = useState("en");
+  const [currency, setCurrency] = useState("usd");
 
   return (
     <CryptoContext.Provider

--- a/src/app/Currency/[crypto]/page.tsx
+++ b/src/app/Currency/[crypto]/page.tsx
@@ -12,7 +12,7 @@ export default function CoinInformation({
 }: {
   params: { crypto: string };
 }) {
-  const { marketData } = useCrypto();
+  const { marketData, currency } = useCrypto();
   const [selectedCoin, setSelectedCoin] = useState(Object);
   const [coinData, setCoinData] = useState();
 
@@ -31,7 +31,7 @@ export default function CoinInformation({
     <main className="flex items-center justify-center mt-20">
       <div className="flex flex-col h-[800px] w-[800px] justify-between">
         {coinData && (
-          <BasicCoinInformation coin={selectedCoin} coinData={coinData} />
+          <BasicCoinInformation coinData={coinData} currency={currency} />
         )}
         {coinData && <CoinDescription coinData={coinData} />}
       </div>

--- a/src/app/Currency/[crypto]/page.tsx
+++ b/src/app/Currency/[crypto]/page.tsx
@@ -36,7 +36,9 @@ export default function CoinInformation({
         {coinData && <CoinDescription coinData={coinData} />}
       </div>
       <div className="flex flex-col h-[800px] w-[800px] justify-between items-center">
-        {coinData && <CoinMarketInformation coin={selectedCoin} />}
+        {coinData && (
+          <CoinMarketInformation coinData={coinData} coin={selectedCoin} currency = {currency} />
+        )}
         {coinData && <CoinLinks coinData={coinData} />}{" "}
       </div>
     </main>

--- a/src/app/api.tsx
+++ b/src/app/api.tsx
@@ -1,8 +1,7 @@
 import axios from "axios";
 
-export async function getCoinInformation() {
-  const coinKey =
-    "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=50&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d";
+export async function getCoinInformation(currency) {
+  const coinKey = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=50&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d`;
   const { data } = await axios(coinKey);
   return data;
 }

--- a/src/app/components/CoinPageComponents/BasicCoinInformation.tsx
+++ b/src/app/components/CoinPageComponents/BasicCoinInformation.tsx
@@ -1,14 +1,15 @@
 "use client";
 import Image from "next/image";
 
-const BasicCoinInformation = ({ coin, coinData }) => {
-  const coinName = coin.name;
-  const currentPrice = coin.current_price;
-  const changeIn24 = coin.price_change_percentage_24h.toFixed(2);
-  const allTimeHigh = coin.ath;
-  const allTimeLow = coin.atl;
-  const symbol = coin.symbol.toUpperCase();
-  const coinImage = coin.image;
+const BasicCoinInformation = ({ coinData, currency }) => {
+  const coinName = coinData.name;
+  const currentPrice = coinData.market_data.current_price[currency];
+  const changeIn24 =
+    coinData.market_data.price_change_percentage_24h.toFixed(2);
+  const allTimeHigh = coinData.market_data.ath[currency];
+  const allTimeLow = coinData.market_data.atl[currency];
+  const symbol = coinData.symbol.toUpperCase();
+  const coinImage = coinData.image.small;
   const link = coinData.links.homepage[0];
 
   const pickColor = (value) => {

--- a/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
+++ b/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
@@ -1,25 +1,23 @@
-const CoinMarketInformation = ({ coin }) => {
-  const marketCap = addCommas(coin.market_cap, 0, true);
+import { addCommas } from "../../utils/utility";
+
+const CoinMarketInformation = ({
+  coin,
+  coinData: { market_data: data },
+  currency,
+}) => {
+  const marketCap = addCommas(data.market_cap[currency], 0, true);
   const fullyDilutedValuation = addCommas(
-    coin.fully_diluted_valuation,
+    data.fully_diluted_valuation[currency],
     0,
     true
   );
-  const volume = addCommas(coin.total_volume, 0, true);
-  const circulatingSupply = addCommas(coin.circulating_supply, 0, true);
-  const maxSupply = addCommas(coin.total_supply, 0, true);
-  const volumeThatDay = addCommas(coin.market_cap_change_24h, 0, true);
-  const volumePerMarket = (coin.total_volume / coin.market_cap).toFixed(5);
-  const percentVPM = (coin.total_volume / coin.market_cap) * 100;
+  const volume = addCommas(data.total_volume[currency], 0, true);
+  const circulatingSupply = addCommas(data.circulating_supply, 0, true);
+  const maxSupply = addCommas(data.total_supply, 0, true);
+  const volumeThatDay = addCommas(data.market_cap_change_24h, 0, true);
+  const percentVPM =
+    (data.total_volume[currency] / data.market_cap[currency]) * 100;
   const symbol = coin.symbol.toUpperCase();
-
-  function addCommas(number, num_decimals, include_comma) {
-    return number.toLocaleString("en-US", {
-      useGrouping: include_comma,
-      minimumFractionDigits: num_decimals,
-      maximumFractionDigits: num_decimals,
-    });
-  }
 
   return (
     <div className="text-white flex w-[500px] bg-[#1e1932] rounded-lg flex-col h-[370px] justify-center items-center text-sm">
@@ -45,7 +43,7 @@ const CoinMarketInformation = ({ coin }) => {
               <div>${marketCap}</div>
               <div>${fullyDilutedValuation}</div>
               <div>${volumeThatDay}</div>
-              <div>{volumePerMarket}</div>
+              <div>{percentVPM.toFixed(2)}%</div>
             </div>
             <div>
               <div>

--- a/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
+++ b/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { addCommas } from "../../utils/utility";
 
 const CoinMarketInformation = ({
@@ -66,9 +67,9 @@ const CoinMarketInformation = ({
         </div>
         <div className="w-[350px] h-[15px] bg-[#f8d2a6]">
           <div
-            className="h-[15px] bg-white"
+            className={"h-[15px] bg-red-500"}
             style={{
-              width: `${percentVPM}px`,
+              width: `${percentVPM}%`,
             }}
           ></div>
         </div>

--- a/src/app/components/MainPageComponents/CoinDetails.tsx
+++ b/src/app/components/MainPageComponents/CoinDetails.tsx
@@ -16,8 +16,8 @@ const CoinDetails = ({ data, spot }) => {
   const totalSupply = (data.total_supply / 10000).toFixed(2);
 
   return (
-    <div className="flex justify-between text-white mt-2.5 mx-2 p-2 rounded-2xl  bg-[#181825]">
-      <div className="flex justify-between items-center w-1/4">
+    <div className="flex justify-between text-white mx-2 p-2 rounded-2xl  bg-[#181825]">
+      <div className="flex justify-between items-center w-1/4 text-center">
         <div className="w-10">{spot + 1}</div>
         <div className="w-40 flex justify-center">
           <Image src={coinImage} width={40} height={40} alt="coin image" />
@@ -25,13 +25,13 @@ const CoinDetails = ({ data, spot }) => {
 
         <div className="w-60 flex justify-center">{coinName}</div>
       </div>
-      <div className="flex justify-between items-center w-1/4">
+      <div className="flex justify-between items-center w-1/3 text-center">
         <div className="w-1/4">${currentPrice}</div>
         <div className="w-1/4">{oneHourChange}%</div>
         <div className="w-1/4">{oneDayChange}%</div>
         <div className="w-1/4">{sevenDayChange}%</div>
       </div>
-      <div className="flex justify-around items-center w-1/3">
+      <div className="flex justify-around items-center w-1/3 text-center">
         <div className="w-1/4">{coinVolume} B</div>
         <div className="w-1/2">{circulatingSupply} : {totalSupply}</div>
         <div className="w-1/4">Graph</div>

--- a/src/app/components/MainPageComponents/CoinDetails.tsx
+++ b/src/app/components/MainPageComponents/CoinDetails.tsx
@@ -11,13 +11,13 @@ const CoinDetails = ({ data, spot }) => {
     data.price_change_percentage_7d_in_currency
   ).toFixed(2);
   const coinImage = data.image;
-  const coinVolume = (data.total_volume /1000000000).toFixed(4);
-  const circulatingSupply = (data.circulating_supply / 10000).toFixed(2);
-  const totalSupply = (data.total_supply / 10000).toFixed(2);
+  const marketCap = data.market_cap;
+  const widthValue = (data.circulating_supply / data.total_supply) * 100;
+  const volumeVsMarketcap = ((data.total_volume / marketCap) * 100).toFixed(2);
 
   return (
     <div className="flex justify-between text-white mx-2 p-2 rounded-2xl  bg-[#181825]">
-      <div className="flex justify-between items-center w-1/4 text-center">
+      <div className="flex justify-between items-center w-1/5 text-center">
         <div className="w-10">{spot + 1}</div>
         <div className="w-40 flex justify-center">
           <Image src={coinImage} width={40} height={40} alt="coin image" />
@@ -25,15 +25,22 @@ const CoinDetails = ({ data, spot }) => {
 
         <div className="w-60 flex justify-center">{coinName}</div>
       </div>
-      <div className="flex justify-between items-center w-1/3 text-center">
+      <div className="flex justify-between items-center w-1/2 text-center">
         <div className="w-1/4">${currentPrice}</div>
         <div className="w-1/4">{oneHourChange}%</div>
         <div className="w-1/4">{oneDayChange}%</div>
         <div className="w-1/4">{sevenDayChange}%</div>
       </div>
-      <div className="flex justify-around items-center w-1/3 text-center">
-        <div className="w-1/4">{coinVolume} B</div>
-        <div className="w-1/2">{circulatingSupply} : {totalSupply}</div>
+      <div className="flex justify-around items-center w-1/4 text-center">
+        {volumeVsMarketcap}%
+        <div className="w-1/4 h-[15px] bg-white">
+          <div
+            className="h-[15px] bg-red-500"
+            style={{
+              width: `${widthValue}%`,
+            }}
+          ></div>
+        </div>
         <div className="w-1/4">Graph</div>
       </div>
     </div>

--- a/src/app/components/NavBar/NavBar.tsx
+++ b/src/app/components/NavBar/NavBar.tsx
@@ -4,7 +4,7 @@ import { useCrypto } from "@/app/Context/CryptoContext";
 import { useRouter } from "next/navigation";
 
 const NavBar = () => {
-  const { marketData } = useCrypto();
+  const { marketData, setCurrency } = useCrypto();
   const router = useRouter();
 
   return (
@@ -39,6 +39,19 @@ const NavBar = () => {
                   {coin.name}
                 </option>
               ))}
+            </select>
+            <select
+              className="w-16 text-black bg-[#13121a] text-white"
+              defaultValue="usd"
+              onChange={(event) => setCurrency(event.target.value)}
+              name=""
+              id=""
+            >
+              <option value="usd">USD</option>
+              <option value="btc">BTC</option>
+              <option value="eth">ETH</option>
+              <option value="eur">EUR</option>
+              <option value="cad">CAD</option>
             </select>
           </div>
         </div>

--- a/src/app/components/NavBar/NavBar.tsx
+++ b/src/app/components/NavBar/NavBar.tsx
@@ -2,10 +2,18 @@
 import Link from "next/link";
 import { useCrypto } from "@/app/Context/CryptoContext";
 import { useRouter } from "next/navigation";
+import { getCoinInformation } from "@/app/api";
 
 const NavBar = () => {
-  const { marketData, setCurrency } = useCrypto();
+  const { marketData, setCurrency, setMarketData } = useCrypto();
   const router = useRouter();
+
+  const updateCurrency = async (event) => {
+    const selectedCurrency = event.target.value;
+    setCurrency(selectedCurrency);
+    const data = await getCoinInformation(selectedCurrency);
+    setMarketData(data);
+  };
 
   return (
     <main className="text-white">
@@ -43,7 +51,7 @@ const NavBar = () => {
             <select
               className="w-16 text-black bg-[#13121a] text-white"
               defaultValue="usd"
-              onChange={(event) => setCurrency(event.target.value)}
+              onChange={updateCurrency}
               name=""
               id=""
             >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import CoinDetails from "./components/MainPageComponents/CoinDetails";
 import CoinStatistics from "./components/MainPageComponents/CoinStatistics";
 import { useCrypto } from "@/app/Context/CryptoContext";
@@ -9,6 +9,7 @@ import { getCoinInformation, getBitCoinData } from "./api";
 export default function Home() {
   const { marketData, setMarketData, bitCoinData, setBitCoinData, currency } =
     useCrypto();
+  const [selectedDays, setSelectedDays] = useState("30");
 
   const collectMarketData = async () => {
     const data = await getCoinInformation(currency);
@@ -18,6 +19,10 @@ export default function Home() {
   const collectBitCoinData = async () => {
     const data = await getBitCoinData();
     setBitCoinData(data);
+  };
+
+  const setDays = (days) => {
+    setSelectedDays(days.target.value);
   };
 
   useEffect(() => {
@@ -33,32 +38,43 @@ export default function Home() {
             <div>Select the currency to view statistics</div>
             <div>Compare box</div>
           </div>
-          <div className="flex overflow-scroll w-1/2">
+          <div className="flex overflow-scroll overflow-y-hidden w-1/2">
             {marketData.map((coin) => (
               <CoinStatistics key={coin.id} data={coin} />
             ))}
           </div>
           <LineChart
             chartData={bitCoinData.prices}
-            numDays={30}
+            numDays={selectedDays}
             title="Bitcoin"
           />
         </div>
-        <div className="flex justify-between text-white mt-2.5 mx-2 p-2 rounded-2xl  bg-[#181825]">
-          <div className="flex justify-between items-center w-1/4 text-center">
+        <div className="flex justify-center items-center text-white space-x-14">
+          <button onClick={setDays} value={7}>
+            7D
+          </button>
+          <button onClick={setDays} value={30}>
+            30D
+          </button>
+          <button onClick={setDays} value={180}>
+            6M
+          </button>
+        </div>
+        <div className="flex justify-between text-white mt-2.5 mx-2 p-2 rounded-2xl  bg-[#181825] mt-5 w-[2481px]">
+          <div className="flex justify-between items-center w-1/5 text-center">
             <div className="w-10">#</div>
-            <div className="w-40 flex justify-center">Image</div>
-
-            <div className="w-60 flex justify-center">Name</div>
+            <div className="w-full">
+              <div className="flex justify-center">Currency</div>
+            </div>
           </div>
-          <div className="flex justify-between items-center w-1/3 text-center">
+          <div className="flex justify-between items-center w-1/2 text-center">
             <div className="w-1/4">Current Price</div>
             <div className="w-1/4">% Change (1H)</div>
             <div className="w-1/4">% Change (1D)</div>
             <div className="w-1/4">% Change (7D)</div>
           </div>
-          <div className="flex justify-around items-center w-1/3 text-center">
-            <div className="w-1/4">Volume (B)</div>
+          <div className="flex justify-between items-center w-1/4 text-center">
+            <div className="w-1/4">Volume vs Market Cap</div>
             <div className="w-1/2">Circulating Supply vs Total Supply</div>
             <div className="w-1/4">Graph</div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,11 @@ import LineChart from "./components/LineChart/LineChart";
 import { getCoinInformation, getBitCoinData } from "./api";
 
 export default function Home() {
-  const { marketData, setMarketData, bitCoinData, setBitCoinData } =
+  const { marketData, setMarketData, bitCoinData, setBitCoinData, currency } =
     useCrypto();
 
   const collectMarketData = async () => {
-    const data = await getCoinInformation();
+    const data = await getCoinInformation(currency);
     setMarketData(data);
   };
 
@@ -44,7 +44,26 @@ export default function Home() {
             title="Bitcoin"
           />
         </div>
-        <div className="mt-8 h-[672px] overflow-scroll overflow-x-hidden">
+        <div className="flex justify-between text-white mt-2.5 mx-2 p-2 rounded-2xl  bg-[#181825]">
+          <div className="flex justify-between items-center w-1/4 text-center">
+            <div className="w-10">#</div>
+            <div className="w-40 flex justify-center">Image</div>
+
+            <div className="w-60 flex justify-center">Name</div>
+          </div>
+          <div className="flex justify-between items-center w-1/3 text-center">
+            <div className="w-1/4">Current Price</div>
+            <div className="w-1/4">% Change (1H)</div>
+            <div className="w-1/4">% Change (1D)</div>
+            <div className="w-1/4">% Change (7D)</div>
+          </div>
+          <div className="flex justify-around items-center w-1/3 text-center">
+            <div className="w-1/4">Volume (B)</div>
+            <div className="w-1/2">Circulating Supply vs Total Supply</div>
+            <div className="w-1/4">Graph</div>
+          </div>
+        </div>
+        <div className="mt-4 h-[672px] overflow-scroll overflow-x-hidden space-y-2">
           {marketData.map((coin, index) => (
             <CoinDetails key={coin.id} data={coin} spot={index} />
           ))}

--- a/src/app/utils/utility.jsx
+++ b/src/app/utils/utility.jsx
@@ -1,0 +1,7 @@
+export function addCommas(number, num_decimals, include_comma) {
+  return number.toLocaleString("en-US", {
+    useGrouping: include_comma,
+    minimumFractionDigits: num_decimals,
+    maximumFractionDigits: num_decimals,
+  });
+}


### PR DESCRIPTION
Patch Notes

- User can now select currency they wish to view from a couple different options. Did not add EVERY currency. I may change this later on. 
- Updated the CoinDetails component. Instead of showing a number it's now volume vs market cap with a bar that fills up based on the value.
- Moved "addCommas" function to a new utilities folder to use where needed.
- Updated all components to use the selected currency if changes were needed.
- Removed the y scroll box for CoinStatistics since you can't scroll it up or down
- Updated the bitcoin graph on the main page so you can select different day ranges. Still need to come back to this and improve it.
- Various css/tailwind updates throughout the app