### PR TITLE
Portfolio page updates. See patch notes

### DIFF
--- a/src/app/Portfolio/EditAssets/page.tsx
+++ b/src/app/Portfolio/EditAssets/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState } from "react";
+import { useCrypto } from "@/app/Context/CryptoContext";
+import EditAssetComponent from "@/app/components/PortfolioPageComponents/EditAssetComponent";
+
+const EditAssets = () => {
+  const { login } = useCrypto();
+  const [pulledCoin, setPulledCoin] = useState();
+
+  const handleSelect = (event) => {
+    const selectedID = event.target.value;
+    const pickedCoin = login.portfolio.find((coin) => coin.id === selectedID);
+    setPulledCoin(pickedCoin);
+  };
+
+  return (
+    <div className="flex justify-center items-center flex-col">
+      <div className="text-white mb-3">
+        Use the drop down to select the asset you wish to edit. Changes will
+        only be reflected once saved.
+      </div>
+      <select
+        defaultValue="default"
+        className="w-36 text-black text-center mb-5"
+        onChange={handleSelect}
+        name="Select2"
+        id="Select3"
+      >
+        <option key="default" value="default" disabled>
+          Select an asset
+        </option>
+        {login.portfolio.map((coin) => (
+          <option key={coin.id} className="text-black" value={coin.id}>
+            {coin.name}
+          </option>
+        ))}
+      </select>
+
+      {pulledCoin && <EditAssetComponent data = {pulledCoin}/>}
+    </div>
+  );
+};
+
+export default EditAssets;

--- a/src/app/Portfolio/page.tsx
+++ b/src/app/Portfolio/page.tsx
@@ -20,7 +20,13 @@ export default function Portfolio() {
     <div className="text-white mx-[15px]">
       <div className="flex flex-col mt-5">
         <div className="flex justify-between px-2.5 mt-10">
-          <p>Your Statistics</p>
+          <p>Your Portfolio</p>
+          <Link
+            className="flex justify-center items-center h-[30px] bg-[#3a3978] px-10 rounded-md"
+            href="/Portfolio/EditAssets"
+          >
+            Edit Portfolio Data
+          </Link>
           <Link
             className="flex justify-center items-center h-[30px] bg-[#3a3978] px-10 rounded-md"
             href="/Portfolio/AddAsset"

--- a/src/app/components/PortfolioPageComponents/DisplayCoinInformation.tsx
+++ b/src/app/components/PortfolioPageComponents/DisplayCoinInformation.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useCrypto } from "@/app/Context/CryptoContext";
 import { uid } from "uid";
 import { useRouter } from "next/navigation";
+import { addCommas } from "@/app/utils/utility";
 
 const DisplayCoinInformation = ({ data }) => {
   const [amount, setAmount] = useState(0);
@@ -12,7 +13,7 @@ const DisplayCoinInformation = ({ data }) => {
   const router = useRouter();
   const coinName = data.name;
   const coinImage = data.image;
-  const currentPrice = data.current_price;
+  const currentPrice = addCommas(data.current_price,2,true);
   const dailyPriceChange = data.price_change_percentage_24h.toFixed(2);
   const symbol = data.symbol;
 
@@ -27,9 +28,9 @@ const DisplayCoinInformation = ({ data }) => {
   const addCoinData = () => {
     const userData = login;
     const coinData = {
-      coin: coinName,
-      totalCoins: amount,
-      totalValue: moneyValue,
+      name: coinName,
+      total_coins: amount,
+      initial_value: moneyValue,
       id: uid(),
       coinID: data.id,
     };
@@ -45,34 +46,42 @@ const DisplayCoinInformation = ({ data }) => {
           {coinName}
           <Image src={coinImage} width={40} height={40} alt="coin image" />
         </div>
-        <div className="w-3/4 flex justify-around flex-col h-full items-center">
+        <div className="w-3/4 flex justify-around flex-col h-full items-center px-24">
           <div>Information related to {coinName}</div>
-          <div className="flex justify-around flex-col items-center w-full">
-            <div>Current Price: {currentPrice}</div>
-            <div>Price Change (24h): {dailyPriceChange}%</div>
-            <div>Symbol: {symbol}</div>
+          <div className="flex justify-between items-center w-full">
+            <div className="space-y-1">
+              <div>Current Price: </div>
+              <div>Price Change (24h): </div>
+              <div>Symbol: </div>
+            </div>
+            <div className="space-y-1 flex flex-col items-end">
+              <div>${currentPrice}</div>
+              <div>{dailyPriceChange}%</div>
+              <div>{symbol.toUpperCase()}</div>
+            </div>
           </div>
 
-          <div className="w-full flex flex-col justify-center items-center space-y-4">
-            <div className="flex space-x-10">
+          <div className="w-full flex justify-between items-center w-full">
+            <div className="space-y-1">
               <div>Enter number of coins you have: </div>
+              <div>Average cost per coin: </div>
+              <div>Initial Value :</div>
+            </div>
+            <div className="space-y-1 flex flex-col items-end">
               <input
-                className="w-[50px] text-black text-center"
+                className="w-[75px] text-black text-center"
                 type="number"
                 value={amount}
                 onChange={changeAmountToAdd}
               />
-            </div>
-            <div className="flex space-x-10">
-              <div>Enter average price per coin: </div>
               <input
-                className="w-[100px] text-black text-center"
+                className="w-[75px] text-black text-center"
                 type="number"
                 value={moneyValue}
                 onChange={changeMoneyValue}
               />
+              <div>${amount * moneyValue}</div>
             </div>
-            <div>Total Value : ${amount * moneyValue}</div>
           </div>
         </div>
       </div>

--- a/src/app/components/PortfolioPageComponents/EditAssetComponent.tsx
+++ b/src/app/components/PortfolioPageComponents/EditAssetComponent.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useCrypto } from "@/app/Context/CryptoContext";
+import { useRouter } from "next/navigation";
+
+const EditAssetComponent = ({ data }) => {
+  const { login, setLogin, saveUserData } = useCrypto();
+  const [amountOfCoins, setAmountOfCoins] = useState(data.total_coins);
+  const [valueOfCoins, setValueOfCoins] = useState(data.initial_value);
+  const router = useRouter();
+
+  const handleEdit = () => {
+    const userData = login;
+    const coinData = {
+      name: data.name,
+      total_coins: amountOfCoins,
+      initial_value: valueOfCoins,
+      id: data.id,
+      coinID: data.coinID,
+    };
+    const spot = userData.portfolio.findIndex(
+      (coin) => coin.id === coinData.id
+    );
+    userData.portfolio[spot] = coinData;
+    setLogin(userData);
+    saveUserData(login);
+    router.push("/Portfolio");
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center text-black h-[300px] w-[600px] bg-[#3a3978] rounded-full">
+      <div>Use the fields below to edit your assets data.</div>
+      <div className="flex w-3/4 justify-around mt-10">
+        <div className="space-y-1">
+          <div>Coin Name:</div>
+          <div>Amount of Coins:</div>
+          <div>Initial Average Price:</div>
+        </div>
+        <div className="flex flex-col space-y-1 items-end">
+          <div>{data.name}</div>
+          <input
+            onChange={(e) => setAmountOfCoins(e.target.value)}
+            className="w-20 text-right"
+            type="number"
+            value={amountOfCoins}
+          />
+          <input
+            onChange={(e) => setValueOfCoins(e.target.value)}
+            className="w-20 text-right"
+            type="number"
+            value={valueOfCoins}
+          />
+        </div>
+      </div>
+      <button
+        onClick={handleEdit}
+        className="flex justify-center items-center h-[30px] bg-[#181825] mt-5 px-10 rounded-md text-white"
+      >
+        Submit
+      </button>
+    </div>
+  );
+};
+
+export default EditAssetComponent;

--- a/src/app/components/PortfolioPageComponents/PortfolioCoin.tsx
+++ b/src/app/components/PortfolioPageComponents/PortfolioCoin.tsx
@@ -13,9 +13,9 @@ const PortfolioCoin = ({ data, handleRemove }) => {
   };
 
   const findBalance = () => {
-    const totalPurchase = data.totalCoins * data.totalValue;
-    const currentValue = coin.current_price * data.totalCoins;
-    return (currentValue - totalPurchase).toFixed(2);
+    const totalPurchase = data.total_coins * data.initial_value;
+    const currentValue = coin.current_price * data.total_coins;
+    return (currentValue - totalPurchase);
   };
 
   useEffect(() => {
@@ -54,15 +54,17 @@ const PortfolioCoin = ({ data, handleRemove }) => {
           <div className="flex justify-between text-xs">
             <div className="flex justify-center items-center flex-col">
               <div>Total Coins</div>
-              <div>{data.totalCoins}</div>
+              <div>{data.total_coins}</div>
             </div>
             <div className="flex justify-center items-center flex-col">
               <div>Original Price</div>
-              <div>${data.totalValue}</div>
+              <div>${data.initial_value}</div>
             </div>
             <div className="flex justify-center items-center flex-col">
               <div>Current Valuation</div>
-              <div>${(data.totalCoins * coin.current_price)?.toFixed(2)}</div>
+              <div>
+                ${data.total_coins * coin.current_price}
+              </div>
             </div>
             <div className="flex justify-center items-center flex-col">
               <div>Gain/Loss</div>


### PR DESCRIPTION
Patch Notes

- User can now edit their portfolio data as they wish. Made it so that you can only change the number of coins you have and their initial purchase value per coin.
- Cleaned up the display when the user is adding a new coin to their portfolio to make it look neater because user experience is bomb
- Cleaned up the coin object that is created so the keys make more sense. Also changed the wording from camalCase to lowercase and underscores (totalCoins => total_coins)
- Various tailwind/css updates and wording changes
- Updates other components that used the coin object so they referenced the correct keys. Because I didn't like seeing NaN everywhere