### PR TITLE
PR

### DIFF
--- a/src/app/api.tsx
+++ b/src/app/api.tsx
@@ -1,26 +1,25 @@
 import axios from "axios";
 
 export async function getCoinInformation(currency) {
-  const coinKey = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=50&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d`;
-  const { data } = await axios(coinKey);
-  return data;
+   const coinKey = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=50&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d`;
+   const { data } = await axios(coinKey);
+   return data;
 }
 
-export async function getBitCoinData() {
-  const dataKey =
-    "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=180&interval=daily";
-  const { data } = await axios(dataKey);
-  return data;
+export async function getDailyPriceFor(coin) {
+   const dataKey = `https://api.coingecko.com/api/v3/coins/${coin}/market_chart?vs_currency=usd&days=365&interval=daily`;
+   const { data } = await axios(dataKey);
+   return data;
 }
 
 export async function getSpecificCoinInfo(coin) {
-  const key = `https://api.coingecko.com/api/v3/coins/${coin}`;
-  const { data } = await axios(key);
-  return data;
+   const key = `https://api.coingecko.com/api/v3/coins/${coin}`;
+   const { data } = await axios(key);
+   return data;
 }
 
 export async function getGlobalData() {
-  const key = "https://api.coingecko.com/api/v3/global";
-  const { data } = await axios(key);
-  return data;
+   const key = "https://api.coingecko.com/api/v3/global";
+   const { data } = await axios(key);
+   return data;
 }

--- a/src/app/components/CoinPageComponents/CoinDescription.tsx
+++ b/src/app/components/CoinPageComponents/CoinDescription.tsx
@@ -1,14 +1,14 @@
 const CoinDescription = ({ coinData, darkMode }) => {
-  const description = coinData.description.en;
+   const description = coinData.description.en;
 
-  return (
-    <div className="flex justify-center items-center ">
-      <div
-        className={`${darkMode ? "duration-300 text-white" : "duration-300 text-[#1e1932]"} w-[800px] text-sm`}
-        dangerouslySetInnerHTML={{ __html: description }}
-      ></div>
-    </div>
-  );
+   return (
+      <div className="flex justify-center items-center ">
+         <div
+            className={`${darkMode ? "duration-300 text-white" : "duration-300 text-[#1e1932]"} w-[800px] text-sm`}
+            dangerouslySetInnerHTML={{ __html: description }}
+         ></div>
+      </div>
+   );
 };
 
 export default CoinDescription;

--- a/src/app/components/CoinPageComponents/CoinLinks.tsx
+++ b/src/app/components/CoinPageComponents/CoinLinks.tsx
@@ -1,34 +1,28 @@
 const CoinLinks = ({ coinData, darkMode }) => {
-  const firstLink = coinData.links.blockchain_site[2];
-  const secondLink = coinData.links.blockchain_site[3];
-  const thirdLink = coinData.links.blockchain_site[4];
+   const firstLink = coinData.links.blockchain_site[2];
+   const secondLink = coinData.links.blockchain_site[3];
+   const thirdLink = coinData.links.blockchain_site[4];
 
-  return (
-    <div className="text-white space-y-5 text-center">
-      {firstLink && (
-        <div
-          className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}
-        >
-          {firstLink}
-        </div>
-      )}
-      {secondLink && (
-        <div
-          className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}
-        >
-          {secondLink}
-        </div>
-      )}
-      {thirdLink && (
-        <div
-          className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}
-        >
-          {thirdLink}
-          {thirdLink}
-        </div>
-      )}
-    </div>
-  );
+   return (
+      <div className="text-white space-y-5 text-center">
+         {firstLink && (
+            <div className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}>
+               {firstLink}
+            </div>
+         )}
+         {secondLink && (
+            <div className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}>
+               {secondLink}
+            </div>
+         )}
+         {thirdLink && (
+            <div className={`flex justify-center items-center ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} p-3 w-[500px] rounded-lg h-[75px]`}>
+               {thirdLink}
+               {thirdLink}
+            </div>
+         )}
+      </div>
+   );
 };
 
 export default CoinLinks;

--- a/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
+++ b/src/app/components/CoinPageComponents/CoinMarketInformation.tsx
@@ -1,84 +1,74 @@
 "use client";
 import { addCommas } from "../../utils/utility";
 
-const CoinMarketInformation = ({
-  coin,
-  coinData: { market_data: data },
-  currency,
-  darkMode,
-}) => {
-  const marketCap = addCommas(data.market_cap[currency], 0, true);
-  const fullyDilutedValuation = addCommas(
-    data.fully_diluted_valuation[currency],
-    0,
-    true,
-  );
-  const volume = addCommas(data.total_volume[currency], 0, true);
-  const circulatingSupply = addCommas(data.circulating_supply, 0, true);
-  const maxSupply = addCommas(data.total_supply, 0, true);
-  const volumeThatDay = addCommas(data.market_cap_change_24h, 0, true);
-  const percentVPM =
-    (data.total_volume[currency] / data.market_cap[currency]) * 100;
-  const symbol = coin.symbol.toUpperCase();
+const CoinMarketInformation = ({ coin, coinData: { market_data: data }, currency, darkMode }) => {
+   const marketCap = addCommas(data.market_cap[currency], 0, true);
+   const fullyDilutedValuation = addCommas(data.fully_diluted_valuation[currency], 0, true);
+   const volume = addCommas(data.total_volume[currency], 0, true);
+   const circulatingSupply = addCommas(data.circulating_supply, 0, true);
+   const maxSupply = addCommas(data.total_supply, 0, true);
+   const volumeThatDay = addCommas(data.market_cap_change_24h, 0, true);
+   const percentVPM = (data.total_volume[currency] / data.market_cap[currency]) * 100;
+   const symbol = coin.symbol.toUpperCase();
 
-  return (
-    <div
-      className={`text-white flex w-[500px] ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} rounded-lg flex-col h-[370px] justify-center items-center text-sm`}
-    >
-      <div className="flex w-[350px]">
-        <div className="flex justify-between w-full">
-          <div className="space-y-6">
-            <div>
-              <div>Market Cap</div>
-              <div>Fully Diluted Valuation</div>
-              <div>Volume 24h</div>
-              <div>Volume/Market</div>
+   return (
+      <div
+         className={`text-white flex w-[500px] ${darkMode ? "duration-300 bg-[#1e1932]" : "duration-300 bg-[#5492f7]"} rounded-lg flex-col h-[370px] justify-center items-center text-sm`}
+      >
+         <div className="flex w-[350px]">
+            <div className="flex justify-between w-full">
+               <div className="space-y-6">
+                  <div>
+                     <div>Market Cap</div>
+                     <div>Fully Diluted Valuation</div>
+                     <div>Volume 24h</div>
+                     <div>Volume/Market</div>
+                  </div>
+                  <div>
+                     <div>Total Volume</div>
+                     <div>Circulating Supply</div>
+                     <div>Max Supply</div>
+                  </div>
+               </div>
             </div>
-            <div>
-              <div>Total Volume</div>
-              <div>Circulating Supply</div>
-              <div>Max Supply</div>
+            <div className="flex justify-between w-full">
+               <div className="space-y-6">
+                  <div>
+                     <div>${marketCap}</div>
+                     <div>${fullyDilutedValuation}</div>
+                     <div>${volumeThatDay}</div>
+                     <div>{percentVPM.toFixed(2)}%</div>
+                  </div>
+                  <div>
+                     <div>
+                        {volume} {symbol}
+                     </div>
+                     <div>
+                        {circulatingSupply} {symbol}
+                     </div>
+                     <div>
+                        {maxSupply} {symbol}
+                     </div>
+                  </div>
+               </div>
             </div>
-          </div>
-        </div>
-        <div className="flex justify-between w-full">
-          <div className="space-y-6">
-            <div>
-              <div>${marketCap}</div>
-              <div>${fullyDilutedValuation}</div>
-              <div>${volumeThatDay}</div>
-              <div>{percentVPM.toFixed(2)}%</div>
+         </div>
+         <div className="flex justify-center mt-12 flex-col">
+            <div className="flex justify-between text-xs mb-1">
+               <div>{percentVPM.toFixed(2)}%</div>
+               <div>{(100 - percentVPM).toFixed(2)}%</div>
             </div>
-            <div>
-              <div>
-                {volume} {symbol}
-              </div>
-              <div>
-                {circulatingSupply} {symbol}
-              </div>
-              <div>
-                {maxSupply} {symbol}
-              </div>
+            <div className="w-[350px] h-[15px] bg-[#f8d2a6]">
+               <div
+                  className={"h-[15px] bg-red-500"}
+                  style={{
+                     width: `${percentVPM}%`,
+                  }}
+               ></div>
             </div>
-          </div>
-        </div>
+         </div>
       </div>
-      <div className="flex justify-center mt-12 flex-col">
-        <div className="flex justify-between text-xs mb-1">
-          <div>{percentVPM.toFixed(2)}%</div>
-          <div>{(100 - percentVPM).toFixed(2)}%</div>
-        </div>
-        <div className="w-[350px] h-[15px] bg-[#f8d2a6]">
-          <div
-            className={"h-[15px] bg-red-500"}
-            style={{
-              width: `${percentVPM}%`,
-            }}
-          ></div>
-        </div>
-      </div>
-    </div>
-  );
+   );
 };
 
 export default CoinMarketInformation;

--- a/src/app/components/ConvertorPageComponents/ConvertorContainer.tsx
+++ b/src/app/components/ConvertorPageComponents/ConvertorContainer.tsx
@@ -6,87 +6,55 @@ import { useCrypto } from "@/app/Context/CryptoContext";
 import { secondaryColor } from "@/app/utils/utility";
 
 const ConvertorContainer = () => {
-  const [leftSelection, setLeftSelection] = useState();
-  const [rightSelection, setRightSelection] = useState();
-  const { marketData, darkMode } = useCrypto();
+   const [leftSelection, setLeftSelection] = useState();
+   const [rightSelection, setRightSelection] = useState();
+   const { marketData, darkMode } = useCrypto();
 
-  const setLeft = (value) => {
-    const selectedCoin = value.target.value;
-    const pickedCoin = marketData.find((coin) => coin.id === selectedCoin);
-    setLeftSelection(pickedCoin);
-  };
+   const setLeft = (value) => {
+      const selectedCoin = value.target.value;
+      const pickedCoin = marketData.find((coin) => coin.id === selectedCoin);
+      setLeftSelection(pickedCoin);
+   };
 
-  const setRight = (value) => {
-    const selectedCoin = value.target.value;
-    const pickedCoin = marketData.find((coin) => coin.id === selectedCoin);
-    setRightSelection(pickedCoin);
-  };
+   const setRight = (value) => {
+      const selectedCoin = value.target.value;
+      const pickedCoin = marketData.find((coin) => coin.id === selectedCoin);
+      setRightSelection(pickedCoin);
+   };
 
-  return (
-    <div className="flex justify-center my-5 flex-col items-center">
-      <div className="text-center">
-        Select a currency you wish to sell and what you would like to convert it
-        to. <br />
-        Note: This will not actually convert your currencies (if any are
-        available)
+   return (
+      <div className="flex justify-center my-5 flex-col items-center">
+         <div className="text-center">
+            Select a currency you wish to sell and what you would like to convert it to. <br />
+            Note: This will not actually convert your currencies
+         </div>
+         <div className={`flex justify-around items-center my-5 py-10 rounded-3xl px-24 duration-300 ${secondaryColor(darkMode)}`}>
+            <ConvertorSelection
+               marketData={marketData}
+               setLeft={setLeft}
+               setRight={setRight}
+            />
+         </div>
+         <div className="flex justify-around my-5 w-[1000px]">
+            <ConvertorDisplay
+               darkMode={darkMode}
+               sellSide={leftSelection}
+               buySide={rightSelection}
+            />
+         </div>
+         <div className="flex flex-col w-screen justify-center items-center">
+            <div className={`flex justify-center h-[500px] w-3/4 items-center rounded-3xl duration-300 ${secondaryColor(darkMode)}`}>This is where the graph will go</div>
+            <div className="flex space-x-1 justify-center items-center mt-5 rounded-3xl p-2 duration-300">
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1D</button>
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>7D</button>
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>14D</button>
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1M</button>
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1Y</button>
+               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>5Y</button>
+            </div>
+         </div>
       </div>
-      <div
-        className={`flex justify-around items-center my-5 py-10 rounded-3xl px-24 duration-300 ${secondaryColor(darkMode)}`}
-      >
-        <ConvertorSelection
-          marketData={marketData}
-          setLeft={setLeft}
-          setRight={setRight}
-        />
-      </div>
-      <div className="flex justify-around my-5 w-[1000px]">
-        <ConvertorDisplay
-          darkMode={darkMode}
-          sellSide={leftSelection}
-          buySide={rightSelection}
-        />
-      </div>
-      <div className="flex flex-col w-screen justify-center items-center">
-        <div
-          className={`flex justify-center h-[500px] w-3/4 items-center rounded-3xl duration-300 ${secondaryColor(darkMode)}`}
-        >
-          This is where the graph will go
-        </div>
-        <div className="flex space-x-1 justify-center items-center mt-5 rounded-3xl p-2 duration-300">
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            1D
-          </button>
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            7D
-          </button>
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            14D
-          </button>
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            1M
-          </button>
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            1Y
-          </button>
-          <button
-            className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
-          >
-            5Y
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+   );
 };
 
 export default ConvertorContainer;

--- a/src/app/components/ConvertorPageComponents/ConvertorContainer.tsx
+++ b/src/app/components/ConvertorPageComponents/ConvertorContainer.tsx
@@ -4,10 +4,12 @@ import ConvertorDisplay from "./ConvertorDisplay";
 import ConvertorSelection from "./ConvertorSelection";
 import { useCrypto } from "@/app/Context/CryptoContext";
 import { secondaryColor } from "@/app/utils/utility";
+import { CoinConvertorLineChart } from "../LineChart/LineChart";
 
 const ConvertorContainer = () => {
    const [leftSelection, setLeftSelection] = useState();
    const [rightSelection, setRightSelection] = useState();
+   const [numberOfDays, setNumberOfDays] = useState("30");
    const { marketData, darkMode } = useCrypto();
 
    const setLeft = (value) => {
@@ -20,6 +22,10 @@ const ConvertorContainer = () => {
       const selectedCoin = value.target.value;
       const pickedCoin = marketData.find((coin) => coin.id === selectedCoin);
       setRightSelection(pickedCoin);
+   };
+
+   const handleDaySelect = (event) => {
+      setNumberOfDays(event.target.value);
    };
 
    return (
@@ -42,17 +48,46 @@ const ConvertorContainer = () => {
                buySide={rightSelection}
             />
          </div>
-         <div className="flex flex-col w-screen justify-center items-center">
-            <div className={`flex justify-center h-[500px] w-3/4 items-center rounded-3xl duration-300 ${secondaryColor(darkMode)}`}>This is where the graph will go</div>
-            <div className="flex space-x-1 justify-center items-center mt-5 rounded-3xl p-2 duration-300">
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1D</button>
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>7D</button>
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>14D</button>
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1M</button>
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>1Y</button>
-               <button className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}>5Y</button>
+         {leftSelection && rightSelection && (
+            <div className="flex flex-col w-screen justify-center items-center">
+               <CoinConvertorLineChart
+                  left={leftSelection}
+                  right={rightSelection}
+                  numDays={numberOfDays}
+               />
+
+               <div className="flex space-x-10 justify-center items-center mt-5 rounded-3xl p-2 duration-300">
+                  <button
+                     onClick={handleDaySelect}
+                     value={7}
+                     className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
+                  >
+                     7D
+                  </button>
+                  <button
+                     onClick={handleDaySelect}
+                     value={14}
+                     className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
+                  >
+                     14D
+                  </button>
+                  <button
+                     onClick={handleDaySelect}
+                     value={30}
+                     className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
+                  >
+                     1M
+                  </button>
+                  <button
+                     onClick={handleDaySelect}
+                     value={90}
+                     className={`px-8 py-2 rounded-full ${secondaryColor(darkMode)}`}
+                  >
+                     3M
+                  </button>
+               </div>
             </div>
-         </div>
+         )}
       </div>
    );
 };

--- a/src/app/components/LineChart/LineChart.tsx
+++ b/src/app/components/LineChart/LineChart.tsx
@@ -1,6 +1,7 @@
 import { Line } from "react-chartjs-2";
 
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from "chart.js";
+import { secondaryColor } from "@/app/utils/utility";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -50,7 +51,43 @@ export function CoinDetailsLineChart({ chartData }) {
    );
 }
 
-export function MainPageLineChart({ data, numDays, type, name }) {
+export function CoinConvertorLineChart({ left, right, numDays }) {
+   const leftData = left.sparkline_in_7d.price.slice(-numDays);
+   const rightData = right.sparkline_in_7d.price.slice(-numDays);
+   const length = numDays;
+
+   const graphObject = {
+      labels: Array.from({ length }, (_, index) => index + 1),
+      datasets: [
+         {
+            data: leftData.map((data, index) => data / rightData[index]),
+            borderColor: "black",
+            borderWidth: 1,
+         },
+      ],
+   };
+
+   return (
+      <div className="h-[500px] w-full flex justify-center">
+         <Line
+            data={graphObject}
+            options={{
+               plugins: {
+                  title: {
+                     display: true,
+                     text: "Convertion Rate",
+                  },
+                  legend: {
+                     position: "bottom",
+                  },
+               },
+            }}
+         />
+      </div>
+   );
+}
+
+export function MainPageLineChart({ data, numDays, type, coin, chartType, darkMode }) {
    const chartData = type === "price" ? data.prices : data.total_volumes;
    const length = numDays;
    const dataForChart = chartData.slice(chartData.length - length);
@@ -58,28 +95,30 @@ export function MainPageLineChart({ data, numDays, type, name }) {
       labels: Array.from({ length }, (_, index) => index + 1),
       datasets: [
          {
-            label: name,
+            label: coin,
             data: dataForChart.map((data) => data),
             borderColor: "black",
             borderWidth: 1,
          },
       ],
-      options: {
-         plugins: {
-            title: {
-               text: "Hello testing",
-               display: true,
-            },
-            tooltip: {
-               enabled: false,
-            },
-         },
-      },
    };
 
    return (
-      <div className="h-[300px] w-full flex justify-center">
-         <Line data={graphObject} />
+      <div className={`h-[500px] w-[1000px] duration-300 rounded-3xl ${secondaryColor(darkMode)} p-5`}>
+         <Line
+            data={graphObject}
+            options={{
+               plugins: {
+                  title: {
+                     display: true,
+                     text: chartType,
+                  },
+                  legend: {
+                     position: "bottom",
+                  },
+               },
+            }}
+         />
       </div>
    );
 }

--- a/src/app/components/LineChart/LineChart.tsx
+++ b/src/app/components/LineChart/LineChart.tsx
@@ -1,103 +1,85 @@
 import { Line } from "react-chartjs-2";
 
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-} from "chart.js";
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from "chart.js";
 
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 export function CoinDetailsLineChart({ chartData }) {
-  if (!chartData) {
-    return <div className="text-red-500">No Data.</div>;
-  }
+   if (!chartData) {
+      return <div className="text-red-500">No Data.</div>;
+   }
 
-  const length = 7;
-  const dataForChart = chartData.slice(chartData.length - length);
-  const graphObject = {
-    labels: Array.from({ length }, (_, index) => index + 1),
-    datasets: [
-      {
-        data: dataForChart.map((data) => data),
-        borderColor: "black",
-        borderWidth: 1,
-      },
-    ],
-  };
+   const length = 7;
+   const dataForChart = chartData.slice(chartData.length - length);
+   const graphObject = {
+      labels: Array.from({ length }, (_, index) => index + 1),
+      datasets: [
+         {
+            data: dataForChart.map((data) => data),
+            borderColor: "black",
+            borderWidth: 1,
+         },
+      ],
+   };
 
-  return (
-    <div className="h-[70px] flex justify-center w-1/3">
-      <Line
-        data={graphObject}
-        options={{
-          scales: {
-            y: {
-              display: false,
-            },
-            x: {
-              display: false,
-            },
-          },
-          responsive: true,
-          plugins: {
-            title: {
-              display: false,
-            },
-            legend: {
-              display: false,
-            },
-          },
-        }}
-      />
-    </div>
-  );
+   return (
+      <div className="h-[70px] flex justify-center w-1/3">
+         <Line
+            data={graphObject}
+            options={{
+               scales: {
+                  y: {
+                     display: false,
+                  },
+                  x: {
+                     display: false,
+                  },
+               },
+               responsive: true,
+               plugins: {
+                  title: {
+                     display: false,
+                  },
+                  legend: {
+                     display: false,
+                  },
+               },
+            }}
+         />
+      </div>
+   );
 }
 
-export function MainPageLineChart({ data, numDays }) {
-  const chartData = data.sparkline_in_7d.price;
-  const length = numDays;
-
-  const dataForChart = chartData.slice(chartData.length - length);
-  const graphObject = {
-    labels: Array.from({ length }, (_, index) => index + 1),
-    datasets: [
-      {
-        label: data.name,
-        data: dataForChart.map((data) => data),
-        borderColor: "black",
-        borderWidth: 1,
+export function MainPageLineChart({ data, numDays, type, name }) {
+   const chartData = type === "price" ? data.prices : data.total_volumes;
+   const length = numDays;
+   const dataForChart = chartData.slice(chartData.length - length);
+   const graphObject = {
+      labels: Array.from({ length }, (_, index) => index + 1),
+      datasets: [
+         {
+            label: name,
+            data: dataForChart.map((data) => data),
+            borderColor: "black",
+            borderWidth: 1,
+         },
+      ],
+      options: {
+         plugins: {
+            title: {
+               text: "Hello testing",
+               display: true,
+            },
+            tooltip: {
+               enabled: false,
+            },
+         },
       },
-    ],
-    options: {
-      plugins: {
-        title: {
-          text: "Hello testing",
-          display: true,
-        },
-        tooltip: {
-          enabled: false,
-        },
-      },
-    },
-  };
+   };
 
-  return (
-    <div className="h-[300px] w-full flex justify-center">
-      <Line data={graphObject} />
-    </div>
-  );
+   return (
+      <div className="h-[300px] w-full flex justify-center">
+         <Line data={graphObject} />
+      </div>
+   );
 }

--- a/src/app/components/MainPageComponents/CoinStatistics.tsx
+++ b/src/app/components/MainPageComponents/CoinStatistics.tsx
@@ -1,37 +1,40 @@
 import Image from "next/image";
-import { addCommas } from "@/app/utils/utility";
+import { addCommas, secondaryColor } from "@/app/utils/utility";
 
 const CoinStatistics = ({ data, handleClick, selected, darkMode }) => {
-  const coinName = data.name;
-  const symbol = data.symbol;
-  const currentPrice = addCommas(data.current_price, 2, true);
-  const oneDayChange = Number(data.price_change_percentage_24h).toFixed(2);
-  const coinImage = data.image;
+   const coinName = data.name;
+   const symbol = data.symbol;
+   const currentPrice = addCommas(data.current_price, 2, true);
+   const oneDayChange = Number(data.price_change_percentage_24h).toFixed(2);
+   const coinImage = data.image;
 
-  const colorSelector = () => {
-    return selected === coinName
-      ? `${darkMode ? "duration-300 bg-[#32324d]" : "duration-300 bg-[#06327a]"}`
-      : `${darkMode ? "duration-300 bg-[#181825]" : "duration-300 bg-[#3b82f6]"}`;
-  };
+   const colorSelector = () => {
+      return selected === coinName ? `${darkMode ? "duration-300 bg-[#32324d]" : "duration-300 bg-[#06327a]"}` : `${secondaryColor(darkMode)}`;
+   };
 
-  return (
-    <div
-      onClick={handleClick}
-      id={data.id}
-      className={`h-[110px] flex justify-between items-center text-white mr-2 rounded-3xl px-2 text-sm ${colorSelector()}`}
-    >
-      <div className="flex justify-center w-14">
-        <Image src={coinImage} width={40} height={40} alt="coin image" />
+   return (
+      <div
+         onClick={handleClick}
+         id={data.id}
+         className={`h-[110px] flex justify-between items-center text-white mr-2 rounded-3xl px-2 text-sm ${colorSelector()}`}
+      >
+         <div className="flex justify-center w-14">
+            <Image
+               src={coinImage}
+               width={40}
+               height={40}
+               alt="coin image"
+            />
+         </div>
+         <div className="w-52 text-center">
+            <div>
+               {coinName} ({symbol.toUpperCase()})
+            </div>
+            <div>${currentPrice}</div>
+         </div>
+         <div className="text-center w-14">{oneDayChange}</div>
       </div>
-      <div className="w-52 text-center">
-        <div>
-          {coinName} ({symbol.toUpperCase()})
-        </div>
-        <div>${currentPrice}</div>
-      </div>
-      <div className="text-center w-14">{oneDayChange}</div>
-    </div>
-  );
+   );
 };
 
 export default CoinStatistics;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ export default function Home() {
    const [sortType, setSortType] = useState(true);
    const [graphData, setGraphData] = useState();
    const [selectedChart, setSelectedChart] = useState();
+   const [collapsed, setCollapsed] = useState(false);
 
    const sortBy = (event) => {
       const sortKey = event.target.value;
@@ -50,8 +51,13 @@ export default function Home() {
       setSortedData(sortedArray);
    };
 
+   const isSelected = (num) => {
+      return `${num == selectedDays ? "z-10" : "z-0"}`;
+   };
+
    const setDays = (days) => {
       setSelectedDays(days.target.value);
+      setCollapsed(!collapsed);
    };
 
    const addToGraph = async (event) => {
@@ -132,43 +138,51 @@ export default function Home() {
                <div className="flex justify-around w-full mt-10">
                   {!graphData && <div className="text-white my-5 text-lg">Please select a coin from above to display price data.</div>}
                   {graphData && (
-                     <div className="flex flex-col justify-around w-full">
-                        <div className="flex">
+                     <div className="flex flex-col items-center space-y-12">
+                        <div className="flex space-x-20">
                            <MainPageLineChart
                               data={graphData}
                               numDays={selectedDays}
                               type={"price"}
-                              name={selectedChart}
+                              coin={selectedChart}
+                              chartType="Price over time"
+                              darkMode={darkMode}
                            />
                            <MainPageLineChart
                               data={graphData}
                               numDays={selectedDays}
                               type={"volume"}
-                              name={selectedChart}
+                              coin={selectedChart}
+                              chartType="Volume over time"
+                              darkMode={darkMode}
                            />
                         </div>
-                        <div className="flex justify-center items-center text-white space-x-14">
+                        <div className={"flex justify-center items-center text-white"}>
                            <button
                               onClick={setDays}
                               value={7}
+                              className={`${secondaryColor(darkMode)} rounded-full py-2 w-12 duration-300 absolute ${isSelected(7)} ${collapsed ? "" : "-translate-x-32"}`}
                            >
                               7D
                            </button>
                            <button
                               onClick={setDays}
                               value={30}
+                              className={`${secondaryColor(darkMode)} rounded-full py-2 w-12 duration-300 absolute ${isSelected(30)} ${collapsed ? "" : "-translate-x-10"}`}
                            >
                               30D
                            </button>
                            <button
                               onClick={setDays}
                               value={180}
+                              className={`${secondaryColor(darkMode)} rounded-full py-2 w-12 duration-300 absolute ${isSelected(180)} ${collapsed ? "" : "translate-x-10"}`}
                            >
                               6M
                            </button>
                            <button
                               onClick={setDays}
                               value={365}
+                              className={`${secondaryColor(darkMode)} rounded-full py-2 w-12 duration-300 absolute ${isSelected(365)} ${collapsed ? "" : "translate-x-32"}`}
                            >
                               1Y
                            </button>
@@ -177,7 +191,7 @@ export default function Home() {
                   )}
                </div>
             </div>
-            <div className="flex justify-center items-center mt-12 space-x-20">
+            <div className="flex justify-center items-center mt-20 space-x-20">
                <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 24 24"
@@ -215,15 +229,20 @@ export default function Home() {
                   >
                      #
                   </button>
-                  <div className="w-full">
-                     <button
-                        onClick={sortBy}
-                        className="flex justify-center"
-                        value="name"
-                     >
-                        Currency
-                     </button>
-                  </div>
+                  <button
+                     onClick={sortBy}
+                     className="flex w-40 justify-center"
+                     value="name"
+                  >
+                     Icon
+                  </button>
+                  <button
+                     onClick={sortBy}
+                     className="w-80 flex justify-center text-sm"
+                     value="name"
+                  >
+                     Currency
+                  </button>
                </div>
                <div className="flex justify-between items-center w-1/3 text-center">
                   <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,236 +5,275 @@ import CoinStatistics from "./components/MainPageComponents/CoinStatistics";
 import { useCrypto } from "@/app/Context/CryptoContext";
 import { MainPageLineChart } from "./components/LineChart/LineChart";
 import { primaryColor, secondaryColor } from "./utils/utility";
+import { getDailyPriceFor } from "./api";
 
 export default function Home() {
-  const { marketData, darkMode } = useCrypto();
-  const [statisticsValue, setStatisticsValue] = useState(0);
-  const [selectedDays, setSelectedDays] = useState("30");
-  const [detailsValue, setDetailsValue] = useState(0);
-  const [sortedData, setSortedData] = useState([]);
-  const [sortType, setSortType] = useState(true);
-  const [graphData, setGraphData] = useState();
-  const [selectedChart, setSelectedChart] = useState();
+   const { marketData, darkMode } = useCrypto();
+   const [statisticsValue, setStatisticsValue] = useState(0);
+   const [selectedDays, setSelectedDays] = useState("30");
+   const [detailsValue, setDetailsValue] = useState(0);
+   const [sortedData, setSortedData] = useState([]);
+   const [sortType, setSortType] = useState(true);
+   const [graphData, setGraphData] = useState();
+   const [selectedChart, setSelectedChart] = useState();
 
-  const sortBy = (event) => {
-    const sortKey = event.target.value;
-    const types = {
-      rank: "market_cap_rank",
-      one_hour: "price_change_percentage_1h_in_currency",
-      one_day: "price_change_24h",
-      current_price: "current_price",
-      seven_day: "price_change_percentage_7d_in_currency",
-      name: "name",
-    };
+   const sortBy = (event) => {
+      const sortKey = event.target.value;
+      const types = {
+         rank: "market_cap_rank",
+         one_hour: "price_change_percentage_1h_in_currency",
+         one_day: "price_change_24h",
+         current_price: "current_price",
+         seven_day: "price_change_percentage_7d_in_currency",
+         name: "name",
+      };
 
-    const sortValue = types[sortKey];
+      const sortValue = types[sortKey];
 
-    const sortedArray = marketData.toSorted((a, b) => {
-      if (sortValue === "name") {
-        if (sortType) {
-          return b[sortValue].localeCompare(a[sortValue]);
-        } else {
-          return a[sortValue].localeCompare(b[sortValue]);
-        }
+      const sortedArray = marketData.toSorted((a, b) => {
+         if (sortValue === "name") {
+            if (sortType) {
+               return b[sortValue].localeCompare(a[sortValue]);
+            } else {
+               return a[sortValue].localeCompare(b[sortValue]);
+            }
+         } else {
+            if (sortType) {
+               return b[sortValue] - a[sortValue];
+            } else {
+               return a[sortValue] - b[sortValue];
+            }
+         }
+      });
+
+      setSortType(!sortType);
+      setSortedData(sortedArray);
+   };
+
+   const setDays = (days) => {
+      setSelectedDays(days.target.value);
+   };
+
+   const addToGraph = async (event) => {
+      const coinWanted = event.target.id;
+      const coinToAdd = marketData.find((coin) => coin.id === coinWanted);
+      const currentCoinData = await getDailyPriceFor(coinToAdd.id);
+      setGraphData(currentCoinData);
+      setSelectedChart(coinToAdd.name);
+   };
+
+   const updateDetailsChart = (amount) => {
+      if (detailsValue + amount < 0) {
+         setDetailsValue(0);
+      } else if (detailsValue + amount > 49) {
+         setDetailsValue(40);
       } else {
-        if (sortType) {
-          return b[sortValue] - a[sortValue];
-        } else {
-          return a[sortValue] - b[sortValue];
-        }
+         setDetailsValue(detailsValue + amount);
       }
-    });
+   };
 
-    setSortType(!sortType);
-    setSortedData(sortedArray);
-  };
+   const updateStatisticsChart = (amount) => {
+      if (statisticsValue + amount < 0) {
+         setStatisticsValue(0);
+      } else if (statisticsValue + amount > 49) {
+         setStatisticsValue(45);
+      } else {
+         setStatisticsValue(statisticsValue + amount);
+      }
+   };
 
-  const setDays = (days) => {
-    setSelectedDays(days.target.value);
-  };
+   useEffect(() => {
+      setSortedData(marketData);
+   }, [marketData]);
 
-  const addToGraph = (event) => {
-    const coinWanted = event.target.id;
-    const coinToAdd = marketData.find((coin) => coin.id === coinWanted);
-    setGraphData(coinToAdd);
-    setSelectedChart(coinToAdd.name);
-  };
-
-  const updateDetailsChart = (amount) => {
-    if (detailsValue + amount < 0) {
-      setDetailsValue(0);
-    } else if (detailsValue + amount > 49) {
-      setDetailsValue(40);
-    } else {
-      setDetailsValue(detailsValue + amount);
-    }
-  };
-
-  const updateStatisticsChart = (amount) => {
-    if (statisticsValue + amount < 0) {
-      setStatisticsValue(0);
-    } else if (statisticsValue + amount > 49) {
-      setStatisticsValue(45);
-    } else {
-      setStatisticsValue(statisticsValue + amount);
-    }
-  };
-
-  useEffect(() => {
-    setSortedData(marketData);
-  }, [marketData]);
-
-  return (
-    <main className={`h-screen duration-300 ${primaryColor(darkMode)}`}>
-      <div className="p-5 text-sm">
-        <div className="flex items-center flex-col">
-          <div className="flex p-8 rounded-3xl w-full justify-center items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill={darkMode ? "white" : "black"}
-              className="duration-300 size-16 mr-5 hover:scale-125 rounded-full"
-              onClick={() => updateStatisticsChart(-5)}
-            >
-              <path
-                fillRule="evenodd"
-                d="M7.28 7.72a.75.75 0 0 1 0 1.06l-2.47 2.47H21a.75.75 0 0 1 0 1.5H4.81l2.47 2.47a.75.75 0 1 1-1.06 1.06l-3.75-3.75a.75.75 0 0 1 0-1.06l3.75-3.75a.75.75 0 0 1 1.06 0Z"
-                clipRule="evenodd"
-              />
-            </svg>
-            {marketData
-              .filter(
-                (_, index) =>
-                  index >= statisticsValue && index <= statisticsValue + 4,
-              )
-              .map((coin) => (
-                <CoinStatistics
-                  key={coin.id}
-                  data={coin}
-                  selected={selectedChart}
-                  handleClick={addToGraph}
-                  darkMode={darkMode}
-                />
-              ))}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill={darkMode ? "white" : "black"}
-              className="duration-300 size-16 mr-5 hover:scale-125 rounded-full"
-              onClick={() => updateStatisticsChart(5)}
-            >
-              <path
-                fillRule="evenodd"
-                d="M16.72 7.72a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1 0 1.06l-3.75 3.75a.75.75 0 1 1-1.06-1.06l2.47-2.47H3a.75.75 0 0 1 0-1.5h16.19l-2.47-2.47a.75.75 0 0 1 0-1.06Z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-          <div className="flex justify-around w-full">
-            {!graphData && (
-              <div className="text-white my-5 text-lg">
-                Please select a coin from above to display price data.
-              </div>
-            )}
-            {graphData && (
-              <div className="flex flex-col justify-around w-full">
-                <MainPageLineChart data={graphData} numDays={selectedDays} />
-                <div className="flex justify-center items-center text-white space-x-14">
-                  <button onClick={setDays} value={7}>
-                    7D
-                  </button>
-                  <button onClick={setDays} value={30}>
-                    30D
-                  </button>
-                  <button onClick={setDays} value={180}>
-                    6M
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="flex justify-center items-center mt-12 space-x-20">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill={darkMode ? "white" : "black"}
-            className="duration-300 size-14 hover:scale-125 rounded-full"
-            onClick={() => updateDetailsChart(-10)}
-          >
-            <path
-              fillRule="evenodd"
-              d="M11.47 2.47a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1-1.06 1.06l-2.47-2.47V21a.75.75 0 0 1-1.5 0V4.81L8.78 7.28a.75.75 0 0 1-1.06-1.06l3.75-3.75Z"
-              clipRule="evenodd"
-            />
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill={darkMode ? "white" : "black"}
-            className="duration-300 size-14 hover:scale-125 rounded-full"
-            onClick={() => updateDetailsChart(10)}
-          >
-            <path
-              fillRule="evenodd"
-              d="M12 2.25a.75.75 0 0 1 .75.75v16.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0l-3.75-3.75a.75.75 0 1 1 1.06-1.06l2.47 2.47V3a.75.75 0 0 1 .75-.75Z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </div>
-
-        <div
-          className={`flex justify-between text-white p-2 rounded-2xl duration-300 ${secondaryColor(darkMode)} mt-5 h-[60px]`}
-        >
-          <div className="flex justify-between items-center w-1/5 text-center">
-            <button onClick={sortBy} className="w-10" value="rank">
-              #
-            </button>
-            <div className="w-full">
-              <button
-                onClick={sortBy}
-                className="flex justify-center"
-                value="name"
-              >
-                Currency
-              </button>
+   return (
+      <main className={`h-screen duration-300 ${primaryColor(darkMode)}`}>
+         <div className="p-5 text-sm">
+            <div className="flex items-center flex-col">
+               <div className="flex p-8 rounded-3xl w-full justify-center items-center">
+                  <svg
+                     xmlns="http://www.w3.org/2000/svg"
+                     viewBox="0 0 24 24"
+                     fill={darkMode ? "white" : "black"}
+                     className="duration-300 size-16 mr-5 hover:scale-125 rounded-full"
+                     onClick={() => updateStatisticsChart(-5)}
+                  >
+                     <path
+                        fillRule="evenodd"
+                        d="M7.28 7.72a.75.75 0 0 1 0 1.06l-2.47 2.47H21a.75.75 0 0 1 0 1.5H4.81l2.47 2.47a.75.75 0 1 1-1.06 1.06l-3.75-3.75a.75.75 0 0 1 0-1.06l3.75-3.75a.75.75 0 0 1 1.06 0Z"
+                        clipRule="evenodd"
+                     />
+                  </svg>
+                  {marketData
+                     .filter((_, index) => index >= statisticsValue && index <= statisticsValue + 4)
+                     .map((coin) => (
+                        <CoinStatistics
+                           key={coin.id}
+                           data={coin}
+                           selected={selectedChart}
+                           handleClick={addToGraph}
+                           darkMode={darkMode}
+                        />
+                     ))}
+                  <svg
+                     xmlns="http://www.w3.org/2000/svg"
+                     viewBox="0 0 24 24"
+                     fill={darkMode ? "white" : "black"}
+                     className="duration-300 size-16 mr-5 hover:scale-125 rounded-full"
+                     onClick={() => updateStatisticsChart(5)}
+                  >
+                     <path
+                        fillRule="evenodd"
+                        d="M16.72 7.72a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1 0 1.06l-3.75 3.75a.75.75 0 1 1-1.06-1.06l2.47-2.47H3a.75.75 0 0 1 0-1.5h16.19l-2.47-2.47a.75.75 0 0 1 0-1.06Z"
+                        clipRule="evenodd"
+                     />
+                  </svg>
+               </div>
+               <div className="flex justify-around w-full mt-10">
+                  {!graphData && <div className="text-white my-5 text-lg">Please select a coin from above to display price data.</div>}
+                  {graphData && (
+                     <div className="flex flex-col justify-around w-full">
+                        <div className="flex">
+                           <MainPageLineChart
+                              data={graphData}
+                              numDays={selectedDays}
+                              type={"price"}
+                              name={selectedChart}
+                           />
+                           <MainPageLineChart
+                              data={graphData}
+                              numDays={selectedDays}
+                              type={"volume"}
+                              name={selectedChart}
+                           />
+                        </div>
+                        <div className="flex justify-center items-center text-white space-x-14">
+                           <button
+                              onClick={setDays}
+                              value={7}
+                           >
+                              7D
+                           </button>
+                           <button
+                              onClick={setDays}
+                              value={30}
+                           >
+                              30D
+                           </button>
+                           <button
+                              onClick={setDays}
+                              value={180}
+                           >
+                              6M
+                           </button>
+                           <button
+                              onClick={setDays}
+                              value={365}
+                           >
+                              1Y
+                           </button>
+                        </div>
+                     </div>
+                  )}
+               </div>
             </div>
-          </div>
-          <div className="flex justify-between items-center w-1/3 text-center">
-            <button onClick={sortBy} className="w-1/4" value="current_price">
-              Current Price
-            </button>
-            <button onClick={sortBy} className="w-1/4" value="one_hour">
-              % Change (1H)
-            </button>
-            <button onClick={sortBy} className="w-1/4" value="one_day">
-              % Change (1D)
-            </button>
-            <button onClick={sortBy} className="w-1/4" value="seven_day">
-              % Change (7D)
-            </button>
-          </div>
-          <div className="flex justify-between items-center w-[680px] text-center">
-            <div className="w-1/3">Volume vs Market Cap</div>
-            <div className="w-1/3">Circulating Supply vs Total Supply</div>
-            <div className="w-1/3">Last 7 Days</div>
-          </div>
-        </div>
-        <div className="mt-4 space-y-2 flex justify-center items-center flex-col w-full">
-          {sortedData
-            .filter(
-              (_, index) => index >= detailsValue && index <= detailsValue + 9,
-            )
-            .map((coin) => (
-              <CoinDetails
-                key={coin.id}
-                data={coin}
-                spot={coin.market_cap_rank}
-                darkMode={darkMode}
-              />
-            ))}
-        </div>
-      </div>
-    </main>
-  );
+            <div className="flex justify-center items-center mt-12 space-x-20">
+               <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill={darkMode ? "white" : "black"}
+                  className="duration-300 size-14 hover:scale-125 rounded-full"
+                  onClick={() => updateDetailsChart(-10)}
+               >
+                  <path
+                     fillRule="evenodd"
+                     d="M11.47 2.47a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1-1.06 1.06l-2.47-2.47V21a.75.75 0 0 1-1.5 0V4.81L8.78 7.28a.75.75 0 0 1-1.06-1.06l3.75-3.75Z"
+                     clipRule="evenodd"
+                  />
+               </svg>
+               <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill={darkMode ? "white" : "black"}
+                  className="duration-300 size-14 hover:scale-125 rounded-full"
+                  onClick={() => updateDetailsChart(10)}
+               >
+                  <path
+                     fillRule="evenodd"
+                     d="M12 2.25a.75.75 0 0 1 .75.75v16.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0l-3.75-3.75a.75.75 0 1 1 1.06-1.06l2.47 2.47V3a.75.75 0 0 1 .75-.75Z"
+                     clipRule="evenodd"
+                  />
+               </svg>
+            </div>
+
+            <div className={`flex justify-between text-white p-2 rounded-2xl duration-300 ${secondaryColor(darkMode)} mt-5 h-[60px]`}>
+               <div className="flex justify-between items-center w-1/5 text-center">
+                  <button
+                     onClick={sortBy}
+                     className="w-10"
+                     value="rank"
+                  >
+                     #
+                  </button>
+                  <div className="w-full">
+                     <button
+                        onClick={sortBy}
+                        className="flex justify-center"
+                        value="name"
+                     >
+                        Currency
+                     </button>
+                  </div>
+               </div>
+               <div className="flex justify-between items-center w-1/3 text-center">
+                  <button
+                     onClick={sortBy}
+                     className="w-1/4"
+                     value="current_price"
+                  >
+                     Current Price
+                  </button>
+                  <button
+                     onClick={sortBy}
+                     className="w-1/4"
+                     value="one_hour"
+                  >
+                     % Change (1H)
+                  </button>
+                  <button
+                     onClick={sortBy}
+                     className="w-1/4"
+                     value="one_day"
+                  >
+                     % Change (1D)
+                  </button>
+                  <button
+                     onClick={sortBy}
+                     className="w-1/4"
+                     value="seven_day"
+                  >
+                     % Change (7D)
+                  </button>
+               </div>
+               <div className="flex justify-between items-center w-[680px] text-center">
+                  <div className="w-1/3">Volume vs Market Cap</div>
+                  <div className="w-1/3">Circulating Supply vs Total Supply</div>
+                  <div className="w-1/3">Last 7 Days</div>
+               </div>
+            </div>
+            <div className="mt-4 space-y-2 flex justify-center items-center flex-col w-full">
+               {sortedData
+                  .filter((_, index) => index >= detailsValue && index <= detailsValue + 9)
+                  .map((coin) => (
+                     <CoinDetails
+                        key={coin.id}
+                        data={coin}
+                        spot={coin.market_cap_rank}
+                        darkMode={darkMode}
+                     />
+                  ))}
+            </div>
+         </div>
+      </main>
+   );
 }


### PR DESCRIPTION
Patch Notes

- Updated utility function so it pulls price for specified coin instead of just bitcoin
- Updated graph on main page so it correctly gets price data for up to 6 months and added a 1 year option. Moved legend so it's below the graph and displays a title. Unable to add 5Y button as api gecko won't allow me to go past 1 year without paying. A full 24 hours will take a little extra time so will come back to that later on.
- Added volume traded graph to main page
- Added transition effect to buttons for main page graph. When you select the days you want the condense only showing the button you selected. When you click them again they expand back out again.
- Added graph to convertor page so user can compare ratio of selected coins.
- Various tailwind/css updates
- Updated prettier settings and ran it on multiple pages. May increase "insertions" and "deletions" significantly. It is just line changes and not "real" changes. To keep the number of files lower I will only run it on a handful of pages per PR update.